### PR TITLE
Add Guava 33.6.0-jre dependency to fg-api

### DIFF
--- a/fg-api/pom.xml
+++ b/fg-api/pom.xml
@@ -8,6 +8,7 @@
 
     <properties>
         <compiler-plugin.version>3.15.0</compiler-plugin.version>
+        <guava.version>33.6.0-jre</guava.version>
         <maven.compiler.release>25</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
@@ -48,6 +49,11 @@
             <groupId>io.rest-assured</groupId>
             <artifactId>rest-assured</artifactId>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>${guava.version}</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
## Summary
- Adds `com.google.guava:guava:33.6.0-jre` to `fg-api/pom.xml`
- Pins the version through a new `guava.version` property so future bumps are a one-line change

## Test plan
- [ ] `mvn -f fg-api/pom.xml dependency:resolve` succeeds and resolves Guava 33.6.0-jre
- [ ] `mvn -f fg-api/pom.xml verify` still passes