### PR TITLE
Add Makefile with verify and clean targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,16 @@
+.PHONY: verify clean help
+.DEFAULT_GOAL := verify
+
+MVN     := ./mvnw
+API_DIR := fg-api
+
+verify:
+	cd $(API_DIR) && $(MVN) verify
+
+clean:
+	cd $(API_DIR) && $(MVN) clean
+
+help:
+	@echo "Targets:"
+	@echo "  verify (default)  Compile fg-api and run all tests (mvn verify)"
+	@echo "  clean             Remove build artifacts"


### PR DESCRIPTION
## Summary
Top-level Makefile that delegates to the Maven Wrapper inside `fg-api/`.

- `make` / `make verify` (default) → `./mvnw verify` (compile + all tests)
- `make clean` → `./mvnw clean`
- `make help` → list targets

## Test plan
- [x] `make verify` runs full Maven lifecycle and passes all 5 unit tests locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)