### PR TITLE
Ignore .envrc and add devbox configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
 replay_pid*
+
+# Local env file (contains secrets like RBAC_GITHUB_TOKEN)
+.envrc

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "java.configuration.updateBuildConfiguration": "interactive"
+}

--- a/devbox.json
+++ b/devbox.json
@@ -1,0 +1,14 @@
+{
+  "$schema":  "https://raw.githubusercontent.com/jetify-com/devbox/0.17.2/.schema/devbox.schema.json",
+  "packages": ["quarkus@latest"],
+  "shell": {
+    "init_hook": [
+      "echo 'Welcome to devbox!' > /dev/null"
+    ],
+    "scripts": {
+      "test": [
+        "echo \"Error: no test specified\" && exit 1"
+      ]
+    }
+  }
+}

--- a/devbox.lock
+++ b/devbox.lock
@@ -1,0 +1,57 @@
+{
+  "lockfile_version": "1",
+  "packages": {
+    "github:NixOS/nixpkgs/nixpkgs-unstable": {
+      "last_modified": "2026-04-23T13:07:47Z",
+      "resolved": "github:NixOS/nixpkgs/01fbdeef22b76df85ea168fbfe1bfd9e63681b30?lastModified=1776949667&narHash=sha256-GMSVw35Q%2B294GlrTUKlx087E31z7KurReQ1YHSKp5iw%3D"
+    },
+    "quarkus@latest": {
+      "last_modified": "2026-04-16T08:46:55Z",
+      "resolved": "github:NixOS/nixpkgs/b86751bc4085f48661017fa226dee99fab6c651b#quarkus",
+      "source": "devbox-search",
+      "version": "3.32.4",
+      "systems": {
+        "aarch64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/vjj1fwplf1a93n4lpjc4fyi6adgr526a-quarkus-cli-3.32.4",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/vjj1fwplf1a93n4lpjc4fyi6adgr526a-quarkus-cli-3.32.4"
+        },
+        "aarch64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/mwzm1dp99i6kvn4wg9b57icccfm2fcky-quarkus-cli-3.32.4",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/mwzm1dp99i6kvn4wg9b57icccfm2fcky-quarkus-cli-3.32.4"
+        },
+        "x86_64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/mq3cqg8n3zc73ypzdwi566qym2ib1707-quarkus-cli-3.32.4",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/mq3cqg8n3zc73ypzdwi566qym2ib1707-quarkus-cli-3.32.4"
+        },
+        "x86_64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/8p30hgwysny16j6j4j97s6dyb6ca8nd9-quarkus-cli-3.32.4",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/8p30hgwysny16j6j4j97s6dyb6ca8nd9-quarkus-cli-3.32.4"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `.envrc` to `.gitignore` (it carries `RBAC_GITHUB_TOKEN` and other local-only env).
- Adds `devbox.json` / `devbox.lock` for the Quarkus dev environment.
- Adds `.vscode/settings.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)