### PR TITLE
[demo] Add failing test to verify CI flags failures

### DIFF
--- a/fg-api/src/test/java/fg/CIFailureDemoTest.java
+++ b/fg-api/src/test/java/fg/CIFailureDemoTest.java
@@ -1,0 +1,13 @@
+package fg;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class CIFailureDemoTest {
+
+    @Test
+    void deliberatelyFails() {
+        assertEquals(1, 2, "intentional failure to verify CI flags failing tests");
+    }
+}


### PR DESCRIPTION
## Summary
- Adds an intentionally failing JUnit test in fg-api so we can confirm CI marks the PR as failed and blocks merging

## Test plan
- [ ] CI workflow runs and reports a FAILING check on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)